### PR TITLE
Add retry logic for transient deployment failures

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -209,11 +209,30 @@ jobs:
             echo "Using target: prod-all (shared + all use cases)"
           fi
           
-          # Deploy bundle with the selected target
+          # Deploy bundle with the selected target (with retry logic)
           echo "Deploying with target: $TARGET"
-          databricks bundle deploy -t $TARGET --auto-approve
           
-          echo "✅ Bundle deployment completed to PROD"
+          # Retry up to 3 times for transient failures
+          MAX_ATTEMPTS=3
+          ATTEMPT=1
+          
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            echo "Deployment attempt $ATTEMPT of $MAX_ATTEMPTS..."
+            
+            if databricks bundle deploy -t $TARGET --auto-approve; then
+              echo "✅ Bundle deployment completed successfully to PROD"
+              break
+            else
+              if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
+                echo "❌ Deployment failed after $MAX_ATTEMPTS attempts"
+                exit 1
+              fi
+              echo "⚠️ Deployment attempt $ATTEMPT failed, retrying in 30 seconds..."
+              sleep 30
+            fi
+            
+            ATTEMPT=$((ATTEMPT + 1))
+          done
       
       - name: Verify PROD Deployment
         env:

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -116,11 +116,30 @@ jobs:
             echo "Using target: test-all (shared + all use cases)"
           fi
           
-          # Deploy bundle with the selected target
+          # Deploy bundle with the selected target (with retry logic)
           echo "Deploying with target: $TARGET"
-          databricks bundle deploy -t $TARGET --auto-approve
           
-          echo "✅ Bundle deployment completed"
+          # Retry up to 3 times for transient failures
+          MAX_ATTEMPTS=3
+          ATTEMPT=1
+          
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            echo "Deployment attempt $ATTEMPT of $MAX_ATTEMPTS..."
+            
+            if databricks bundle deploy -t $TARGET --auto-approve; then
+              echo "✅ Bundle deployment completed successfully"
+              break
+            else
+              if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
+                echo "❌ Deployment failed after $MAX_ATTEMPTS attempts"
+                exit 1
+              fi
+              echo "⚠️ Deployment attempt $ATTEMPT failed, retrying in 30 seconds..."
+              sleep 30
+            fi
+            
+            ATTEMPT=$((ATTEMPT + 1))
+          done
       
       - name: Verify Deployment
         env:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -50,10 +50,28 @@ jobs:
           echo "================================================"
           
           # Deploy using bundle (includes all paths defined in dev target)
-          databricks bundle deploy -t dev --auto-approve
+          # Retry up to 3 times for transient failures
+          MAX_ATTEMPTS=3
+          ATTEMPT=1
           
-          echo "Bundle deployment completed"
-          echo "Deployed to shared DEV workspace"
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            echo "Deployment attempt $ATTEMPT of $MAX_ATTEMPTS..."
+            
+            if databricks bundle deploy -t dev --auto-approve; then
+              echo "Bundle deployment completed"
+              echo "Deployed to shared DEV workspace"
+              break
+            else
+              if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
+                echo "❌ Deployment failed after $MAX_ATTEMPTS attempts"
+                exit 1
+              fi
+              echo "⚠️ Deployment attempt $ATTEMPT failed, retrying in 30 seconds..."
+              sleep 30
+            fi
+            
+            ATTEMPT=$((ATTEMPT + 1))
+          done
       
       - name: Verify Deployment
         env:


### PR DESCRIPTION
- Added 3-attempt retry logic to all bundle deployments
- Handles temporary network issues like 503 errors from provider registry
- 30-second wait between retry attempts
- Prevents workflow failures due to transient infrastructure issues
- Applied to pr-validation, deploy-test, and deploy-prod workflows