### PR TITLE
Remove retry logic from deployment workflows

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -209,30 +209,11 @@ jobs:
             echo "Using target: prod-all (shared + all use cases)"
           fi
           
-          # Deploy bundle with the selected target (with retry logic)
+          # Deploy bundle with the selected target
           echo "Deploying with target: $TARGET"
+          databricks bundle deploy -t $TARGET --auto-approve
           
-          # Retry up to 3 times for transient failures
-          MAX_ATTEMPTS=3
-          ATTEMPT=1
-          
-          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            echo "Deployment attempt $ATTEMPT of $MAX_ATTEMPTS..."
-            
-            if databricks bundle deploy -t $TARGET --auto-approve; then
-              echo "✅ Bundle deployment completed successfully to PROD"
-              break
-            else
-              if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
-                echo "❌ Deployment failed after $MAX_ATTEMPTS attempts"
-                exit 1
-              fi
-              echo "⚠️ Deployment attempt $ATTEMPT failed, retrying in 30 seconds..."
-              sleep 30
-            fi
-            
-            ATTEMPT=$((ATTEMPT + 1))
-          done
+          echo "✅ Bundle deployment completed to PROD"
       
       - name: Verify PROD Deployment
         env:

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -116,30 +116,11 @@ jobs:
             echo "Using target: test-all (shared + all use cases)"
           fi
           
-          # Deploy bundle with the selected target (with retry logic)
+          # Deploy bundle with the selected target
           echo "Deploying with target: $TARGET"
+          databricks bundle deploy -t $TARGET --auto-approve
           
-          # Retry up to 3 times for transient failures
-          MAX_ATTEMPTS=3
-          ATTEMPT=1
-          
-          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            echo "Deployment attempt $ATTEMPT of $MAX_ATTEMPTS..."
-            
-            if databricks bundle deploy -t $TARGET --auto-approve; then
-              echo "✅ Bundle deployment completed successfully"
-              break
-            else
-              if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
-                echo "❌ Deployment failed after $MAX_ATTEMPTS attempts"
-                exit 1
-              fi
-              echo "⚠️ Deployment attempt $ATTEMPT failed, retrying in 30 seconds..."
-              sleep 30
-            fi
-            
-            ATTEMPT=$((ATTEMPT + 1))
-          done
+          echo "✅ Bundle deployment completed"
       
       - name: Verify Deployment
         env:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -50,28 +50,10 @@ jobs:
           echo "================================================"
           
           # Deploy using bundle (includes all paths defined in dev target)
-          # Retry up to 3 times for transient failures
-          MAX_ATTEMPTS=3
-          ATTEMPT=1
+          databricks bundle deploy -t dev --auto-approve
           
-          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            echo "Deployment attempt $ATTEMPT of $MAX_ATTEMPTS..."
-            
-            if databricks bundle deploy -t dev --auto-approve; then
-              echo "Bundle deployment completed"
-              echo "Deployed to shared DEV workspace"
-              break
-            else
-              if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
-                echo "❌ Deployment failed after $MAX_ATTEMPTS attempts"
-                exit 1
-              fi
-              echo "⚠️ Deployment attempt $ATTEMPT failed, retrying in 30 seconds..."
-              sleep 30
-            fi
-            
-            ATTEMPT=$((ATTEMPT + 1))
-          done
+          echo "Bundle deployment completed"
+          echo "Deployed to shared DEV workspace"
       
       - name: Verify Deployment
         env:


### PR DESCRIPTION
- Removed retry logic from all workflows as per user request
- Deployments now fail immediately on error
- Simplified back to single deployment attempt