### PR TITLE
Fix empty ticks in deployment summary

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -297,15 +297,16 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Deployed Structure" >> $GITHUB_STEP_SUMMARY
           echo "Bundle deployment creates the following structure:" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ `/Workspace/Deployments/prod/files/src/shared`" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ \`/Workspace/Deployments/prod/files/src/shared\`" >> $GITHUB_STEP_SUMMARY
           
-          if [ "${{ github.event.inputs.use_case }}" = "all" ]; then
-            echo "- ✅ `/Workspace/Deployments/prod/files/src/usecase-1`" >> $GITHUB_STEP_SUMMARY
-            echo "- ✅ `/Workspace/Deployments/prod/files/src/usecase-2`" >> $GITHUB_STEP_SUMMARY
-          elif [ "${{ github.event.inputs.use_case }}" = "usecase-1" ]; then
-            echo "- ✅ `/Workspace/Deployments/prod/files/src/usecase-1`" >> $GITHUB_STEP_SUMMARY
-          elif [ "${{ github.event.inputs.use_case }}" = "usecase-2" ]; then
-            echo "- ✅ `/Workspace/Deployments/prod/files/src/usecase-2`" >> $GITHUB_STEP_SUMMARY
+          USE_CASE="${{ github.event.inputs.use_case }}"
+          if [ "$USE_CASE" = "all" ]; then
+            echo "- ✅ \`/Workspace/Deployments/prod/files/src/usecase-1\`" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ \`/Workspace/Deployments/prod/files/src/usecase-2\`" >> $GITHUB_STEP_SUMMARY
+          elif [ "$USE_CASE" = "usecase-1" ]; then
+            echo "- ✅ \`/Workspace/Deployments/prod/files/src/usecase-1\`" >> $GITHUB_STEP_SUMMARY
+          elif [ "$USE_CASE" = "usecase-2" ]; then
+            echo "- ✅ \`/Workspace/Deployments/prod/files/src/usecase-2\`" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Backup Location" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -204,15 +204,16 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Deployed Structure" >> $GITHUB_STEP_SUMMARY
           echo "Bundle deployment creates the following structure:" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ `/Workspace/Deployments/test/files/src/shared`" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ \`/Workspace/Deployments/test/files/src/shared\`" >> $GITHUB_STEP_SUMMARY
           
-          if [ "${{ github.event.inputs.use_case }}" = "all" ]; then
-            echo "- ✅ `/Workspace/Deployments/test/files/src/usecase-1`" >> $GITHUB_STEP_SUMMARY
-            echo "- ✅ `/Workspace/Deployments/test/files/src/usecase-2`" >> $GITHUB_STEP_SUMMARY
-          elif [ "${{ github.event.inputs.use_case }}" = "usecase-1" ]; then
-            echo "- ✅ `/Workspace/Deployments/test/files/src/usecase-1`" >> $GITHUB_STEP_SUMMARY
-          elif [ "${{ github.event.inputs.use_case }}" = "usecase-2" ]; then
-            echo "- ✅ `/Workspace/Deployments/test/files/src/usecase-2`" >> $GITHUB_STEP_SUMMARY
+          USE_CASE="${{ github.event.inputs.use_case }}"
+          if [ "$USE_CASE" = "all" ]; then
+            echo "- ✅ \`/Workspace/Deployments/test/files/src/usecase-1\`" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ \`/Workspace/Deployments/test/files/src/usecase-2\`" >> $GITHUB_STEP_SUMMARY
+          elif [ "$USE_CASE" = "usecase-1" ]; then
+            echo "- ✅ \`/Workspace/Deployments/test/files/src/usecase-1\`" >> $GITHUB_STEP_SUMMARY
+          elif [ "$USE_CASE" = "usecase-2" ]; then
+            echo "- ✅ \`/Workspace/Deployments/test/files/src/usecase-2\`" >> $GITHUB_STEP_SUMMARY
           fi
           
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- Fixed conditional logic in deployment summary sections
- Store GitHub Actions expression in shell variable first
- Added backticks around paths for better markdown formatting
- Fixed both deploy-test.yml and deploy-prod.yml
- Summary now correctly shows which folders were deployed