### PR TITLE
Remove strict change ticket format validation

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -54,9 +54,9 @@ jobs:
       - name: Validate inputs
         id: validation
         run: |
-          # Validate change ticket format (example: CHG-12345)
-          if [[ ! "${{ github.event.inputs.change_ticket }}" =~ ^[A-Z]+-[0-9]+$ ]]; then
-            echo "❌ Invalid change ticket format. Expected format: CHG-12345"
+          # Just ensure change ticket is not empty
+          if [ -z "${{ github.event.inputs.change_ticket }}" ]; then
+            echo "❌ Change ticket is required"
             echo "proceed=false" >> $GITHUB_OUTPUT
             exit 1
           fi
@@ -69,6 +69,8 @@ jobs:
           fi
           
           echo "✅ All validations passed"
+          echo "✅ Change ticket: ${{ github.event.inputs.change_ticket }}"
+          echo "✅ Deployment reason: ${{ github.event.inputs.deployment_reason }}"
           echo "proceed=true" >> $GITHUB_OUTPUT
       
       - name: Check TEST deployment status


### PR DESCRIPTION
- Removed regex validation for change ticket format
- Now only checks that change ticket is not empty
- Accepts any string as change ticket (e.g., CHG-12345, JIRA-123, etc.)
- Still validates that deployment reason is provided
- More flexible for different ticketing systems