### PR TITLE
Fix three deployment issues

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -84,9 +84,7 @@ jobs:
     if: needs.pre-deployment-checks.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     name: Deploy to PROD Environment
-    environment: 
-      name: production
-      url: https://databricks-prod.example.com
+    environment: production
     
     steps:
       - name: Checkout code
@@ -140,14 +138,20 @@ jobs:
           BACKUP_PATH="/Workspace/Deployments/prod-backups/${BACKUP_DATE}"
           
           # Create backup directory using the correct target
-          databricks workspace mkdirs "${BACKUP_PATH}" -t $TARGET
+          databricks workspace mkdirs "${BACKUP_PATH}" -t $TARGET || true
           
           # Export current deployment as backup (if exists) - bundle structure
           echo "Backing up current deployment..."
-          databricks workspace export-dir \
-            /Workspace/Deployments/prod/files \
-            "./backup-prod-${BACKUP_DATE}" \
-            --overwrite -t $TARGET || echo "No existing deployment to backup"
+          # Check if source exists before backing up
+          if databricks workspace ls /Workspace/Deployments/prod/files -t $TARGET 2>/dev/null; then
+            databricks workspace export-dir \
+              /Workspace/Deployments/prod/files \
+              "${BACKUP_PATH}" \
+              --overwrite -t $TARGET
+            echo "✅ Backup created at workspace path: ${BACKUP_PATH}"
+          else
+            echo "⚠️ No existing deployment found to backup"
+          fi
           
           echo "Backup completed: ${BACKUP_PATH}"
           echo "backup_path=${BACKUP_PATH}" >> $GITHUB_ENV

--- a/databricks.yml
+++ b/databricks.yml
@@ -6,12 +6,58 @@ variables:
     description: Which use case to deploy
     default: all
 
+resources:
+  clusters:
+    dev-cluster:
+      cluster_name: dev-cluster
+      spark_version: "14.3.x-scala2.12"
+      node_type_id: "Standard_DS3_v2"
+      num_workers: 0
+      autotermination_minutes: 10
+      spark_conf:
+        "spark.databricks.cluster.profile": "singleNode"
+        "spark.master": "local[*]"
+      custom_tags:
+        Environment: "Development"
+        Project: "nanba-selective-cicd"
+    
+    test-cluster:
+      cluster_name: test-cluster
+      spark_version: "14.3.x-scala2.12"
+      node_type_id: "Standard_DS3_v2"
+      num_workers: 0
+      autotermination_minutes: 10
+      spark_conf:
+        "spark.databricks.cluster.profile": "singleNode"
+        "spark.master": "local[*]"
+      custom_tags:
+        Environment: "Testing"
+        Project: "nanba-selective-cicd"
+    
+    prod-cluster:
+      cluster_name: prod-cluster
+      spark_version: "14.3.x-scala2.12"
+      node_type_id: "Standard_DS3_v2"
+      num_workers: 0
+      autotermination_minutes: 10
+      spark_conf:
+        "spark.databricks.cluster.profile": "singleNode"
+        "spark.master": "local[*]"
+      custom_tags:
+        Environment: "Production"
+        Project: "nanba-selective-cicd"
+
 targets:
   # Development target - deploys everything for PR validation
   dev:
     mode: production
     workspace:
       root_path: /Workspace/Deployments/dev
+    
+    resources:
+      clusters:
+        dev-cluster:
+          cluster_name: dev-cluster
     
     sync:
       paths:
@@ -30,6 +76,11 @@ targets:
     workspace:
       root_path: /Workspace/Deployments/test
     
+    resources:
+      clusters:
+        test-cluster:
+          cluster_name: test-cluster
+    
     sync:
       paths:
         - ./src/shared
@@ -45,6 +96,11 @@ targets:
     workspace:
       root_path: /Workspace/Deployments/test
     
+    resources:
+      clusters:
+        test-cluster:
+          cluster_name: test-cluster
+    
     sync:
       paths:
         - ./src/shared
@@ -59,6 +115,11 @@ targets:
     mode: production
     workspace:
       root_path: /Workspace/Deployments/test
+    
+    resources:
+      clusters:
+        test-cluster:
+          cluster_name: test-cluster
     
     sync:
       paths:
@@ -76,6 +137,11 @@ targets:
     mode: production
     workspace:
       root_path: /Workspace/Deployments/prod
+    
+    resources:
+      clusters:
+        prod-cluster:
+          cluster_name: prod-cluster
     
     sync:
       paths:
@@ -96,6 +162,11 @@ targets:
     workspace:
       root_path: /Workspace/Deployments/prod
     
+    resources:
+      clusters:
+        prod-cluster:
+          cluster_name: prod-cluster
+    
     sync:
       paths:
         - ./src/shared
@@ -114,6 +185,11 @@ targets:
     mode: production
     workspace:
       root_path: /Workspace/Deployments/prod
+    
+    resources:
+      clusters:
+        prod-cluster:
+          cluster_name: prod-cluster
     
     sync:
       paths:


### PR DESCRIPTION
1. Fixed empty backup folder:
   - Now backs up to workspace path instead of local file
   - Checks if source exists before attempting backup
   - Stores backup in /Workspace/Deployments/prod-backups/

2. Removed sample URL from prod deployment:
   - Removed url: https://databricks-prod.example.com
   - Keeps environment name without the sample URL

3. Added cluster resources to databricks.yml:
   - Defined dev-cluster, test-cluster, prod-cluster resources
   - Each target now includes appropriate cluster configuration
   - Clusters will be created/updated during bundle deployment
   - Single-node configuration with 10 min auto-termination