### PR TITLE
FIX: Broken YAML syntax preventing manual workflow triggers

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -361,7 +361,6 @@ jobs:
           echo "### Deployment Information" >> $GITHUB_STEP_SUMMARY
           echo "- **Environment:** PRODUCTION" >> $GITHUB_STEP_SUMMARY
           echo "- **Use Case:** ${{ github.event.inputs.use_case }}" >> $GITHUB_STEP_SUMMARY
- >> $GITHUB_STEP_SUMMARY
           echo "- **Change Ticket:** ${{ github.event.inputs.change_ticket }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Status:** ✅ Success" >> $GITHUB_STEP_SUMMARY
           echo "- **Deployed by:** ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -221,7 +221,6 @@ jobs:
           echo "### Deployment Information" >> $GITHUB_STEP_SUMMARY
           echo "- **Environment:** TEST" >> $GITHUB_STEP_SUMMARY
           echo "- **Use Case:** ${{ github.event.inputs.use_case }}" >> $GITHUB_STEP_SUMMARY
- >> $GITHUB_STEP_SUMMARY
           echo "- **Status:** ✅ Success" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Deployed Structure" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Critical fix for GitHub Actions:
- Removed orphaned '>> $GITHUB_STEP_SUMMARY' lines in both workflows
- These were causing YAML parsing errors
- This prevented GitHub from recognizing workflow_dispatch triggers
- 'Run workflow' button was not appearing due to this syntax error

Files fixed:
- .github/workflows/deploy-prod.yml (line 364)
- .github/workflows/deploy-test.yml (line 224)

This should restore the manual trigger functionality.