### PR TITLE
Fix 'please specify target' error for all workspace commands

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -113,6 +113,7 @@ jobs:
         env:
           DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+          DATABRICKS_BUNDLE_ROOT: ""  # Disable bundle config for workspace commands
         run: |
           echo "Creating backup of current PROD deployment..."
           
@@ -123,64 +124,76 @@ jobs:
           # Create local backup directory
           mkdir -p "${LOCAL_BACKUP_DIR}"
           
-          # Try to backup all folders - if they don't exist, the commands will fail gracefully
-          echo "Attempting to backup existing deployment..."
+          # Move to parent directory to avoid bundle config interference
+          cd ..
           
-          # Use DATABRICKS_CONFIG_PROFILE to avoid bundle config interference
-          export DATABRICKS_CONFIG_PROFILE=DEFAULT
+          echo "Attempting to backup existing deployment..."
           
           # Backup shared folder
           echo "Backing up shared folder..."
           databricks workspace export-dir \
             /Workspace/Deployments/prod/files/src/shared \
-            "${LOCAL_BACKUP_DIR}/shared" \
+            "${GITHUB_WORKSPACE}/${LOCAL_BACKUP_DIR}/shared" \
             --overwrite 2>/dev/null || echo "No shared folder found to backup"
           
           # Backup usecase-1
           echo "Backing up usecase-1..."
           databricks workspace export-dir \
             /Workspace/Deployments/prod/files/src/usecase-1 \
-            "${LOCAL_BACKUP_DIR}/usecase-1" \
+            "${GITHUB_WORKSPACE}/${LOCAL_BACKUP_DIR}/usecase-1" \
             --overwrite 2>/dev/null || echo "No usecase-1 found to backup"
           
           # Backup usecase-2
           echo "Backing up usecase-2..."
           databricks workspace export-dir \
             /Workspace/Deployments/prod/files/src/usecase-2 \
-            "${LOCAL_BACKUP_DIR}/usecase-2" \
+            "${GITHUB_WORKSPACE}/${LOCAL_BACKUP_DIR}/usecase-2" \
             --overwrite 2>/dev/null || echo "No usecase-2 found to backup"
           
-          # Create backup directory in workspace
-          databricks workspace mkdirs "${BACKUP_PATH}/src" || true
+          # Return to workspace directory
+          cd "${GITHUB_WORKSPACE}"
           
-          # Upload all backed up content to workspace backup location
+          # Create backup directory in workspace (from outside bundle root)
+          cd ..
+          databricks workspace mkdirs "${BACKUP_PATH}/src" || true
+          cd "${GITHUB_WORKSPACE}"
+          
+          # Upload all backed up content to workspace backup location (from outside bundle root)
           if [ -d "${LOCAL_BACKUP_DIR}/shared" ]; then
             echo "Uploading shared backup..."
+            cd ..
             databricks workspace import-dir \
-              "${LOCAL_BACKUP_DIR}/shared" \
+              "${GITHUB_WORKSPACE}/${LOCAL_BACKUP_DIR}/shared" \
               "${BACKUP_PATH}/src/shared" \
               --overwrite || echo "Failed to upload shared backup"
+            cd "${GITHUB_WORKSPACE}"
           fi
           
           if [ -d "${LOCAL_BACKUP_DIR}/usecase-1" ]; then
             echo "Uploading usecase-1 backup..."
+            cd ..
             databricks workspace import-dir \
-              "${LOCAL_BACKUP_DIR}/usecase-1" \
+              "${GITHUB_WORKSPACE}/${LOCAL_BACKUP_DIR}/usecase-1" \
               "${BACKUP_PATH}/src/usecase-1" \
               --overwrite || echo "Failed to upload usecase-1 backup"
+            cd "${GITHUB_WORKSPACE}"
           fi
           
           if [ -d "${LOCAL_BACKUP_DIR}/usecase-2" ]; then
             echo "Uploading usecase-2 backup..."
+            cd ..
             databricks workspace import-dir \
-              "${LOCAL_BACKUP_DIR}/usecase-2" \
+              "${GITHUB_WORKSPACE}/${LOCAL_BACKUP_DIR}/usecase-2" \
               "${BACKUP_PATH}/src/usecase-2" \
               --overwrite || echo "Failed to upload usecase-2 backup"
+            cd "${GITHUB_WORKSPACE}"
           fi
           
-          # List backup contents for verification
+          # List backup contents for verification (from outside bundle root)
           echo "Backup contents:"
+          cd ..
           databricks workspace ls -l "${BACKUP_PATH}/src" 2>/dev/null || echo "No backup created"
+          cd "${GITHUB_WORKSPACE}"
           
           # Clean up local backup directory
           rm -rf "${LOCAL_BACKUP_DIR}"
@@ -219,6 +232,7 @@ jobs:
         env:
           DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+          DATABRICKS_BUNDLE_ROOT: ""  # Disable bundle config for workspace commands
         run: |
           echo "Deploying selected use cases to PROD..."
           echo "Use Case: ${{ github.event.inputs.use_case }}"
@@ -240,13 +254,16 @@ jobs:
             cp -r src/${{ github.event.inputs.use_case }} "$TEMP_DIR/"
           fi
           
+          # Move to parent directory to avoid bundle config requiring target
+          cd ..
+          
           # Ensure deployment directories exist
           databricks workspace mkdirs /Workspace/Deployments/prod/files/src || true
           
           # Upload shared folder
           echo "Uploading shared folder..."
           databricks workspace import-dir \
-            "$TEMP_DIR/shared" \
+            "${GITHUB_WORKSPACE}/$TEMP_DIR/shared" \
             "/Workspace/Deployments/prod/files/src/shared" \
             --overwrite
           
@@ -254,30 +271,34 @@ jobs:
           if [ "${{ github.event.inputs.use_case }}" = "all" ]; then
             echo "Uploading usecase-1..."
             databricks workspace import-dir \
-              "$TEMP_DIR/usecase-1" \
+              "${GITHUB_WORKSPACE}/$TEMP_DIR/usecase-1" \
               "/Workspace/Deployments/prod/files/src/usecase-1" \
               --overwrite
             
             echo "Uploading usecase-2..."
             databricks workspace import-dir \
-              "$TEMP_DIR/usecase-2" \
+              "${GITHUB_WORKSPACE}/$TEMP_DIR/usecase-2" \
               "/Workspace/Deployments/prod/files/src/usecase-2" \
               --overwrite
           elif [ "${{ github.event.inputs.use_case }}" = "usecase-1" ]; then
             echo "Uploading usecase-1..."
             databricks workspace import-dir \
-              "$TEMP_DIR/usecase-1" \
+              "${GITHUB_WORKSPACE}/$TEMP_DIR/usecase-1" \
               "/Workspace/Deployments/prod/files/src/usecase-1" \
               --overwrite
           elif [ "${{ github.event.inputs.use_case }}" = "usecase-2" ]; then
             echo "Uploading usecase-2..."
             databricks workspace import-dir \
-              "$TEMP_DIR/usecase-2" \
+              "${GITHUB_WORKSPACE}/$TEMP_DIR/usecase-2" \
               "/Workspace/Deployments/prod/files/src/usecase-2" \
               --overwrite
           fi
           
-          # Clean up temp directory
+          # Return to workspace directory
+          cd "${GITHUB_WORKSPACE}"
+          
+          # Clean up temp directory (ensure we're in the right directory)
+          cd "${GITHUB_WORKSPACE}"
           rm -rf "$TEMP_DIR"
           
           # Deploy cluster configuration

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -79,6 +79,7 @@ jobs:
         env:
           DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+          DATABRICKS_BUNDLE_ROOT: ""  # Disable bundle config for workspace commands
         run: |
           echo "Deploying selected use cases to TEST..."
           echo "Use Case: ${{ github.event.inputs.use_case }}"
@@ -100,13 +101,16 @@ jobs:
             cp -r src/${{ github.event.inputs.use_case }} "$TEMP_DIR/"
           fi
           
+          # Move to parent directory to avoid bundle config requiring target
+          cd ..
+          
           # Ensure deployment directories exist
           databricks workspace mkdirs /Workspace/Deployments/test/files/src || true
           
           # Upload shared folder
           echo "Uploading shared folder..."
           databricks workspace import-dir \
-            "$TEMP_DIR/shared" \
+            "${GITHUB_WORKSPACE}/$TEMP_DIR/shared" \
             "/Workspace/Deployments/test/files/src/shared" \
             --overwrite
           
@@ -114,30 +118,34 @@ jobs:
           if [ "${{ github.event.inputs.use_case }}" = "all" ]; then
             echo "Uploading usecase-1..."
             databricks workspace import-dir \
-              "$TEMP_DIR/usecase-1" \
+              "${GITHUB_WORKSPACE}/$TEMP_DIR/usecase-1" \
               "/Workspace/Deployments/test/files/src/usecase-1" \
               --overwrite
             
             echo "Uploading usecase-2..."
             databricks workspace import-dir \
-              "$TEMP_DIR/usecase-2" \
+              "${GITHUB_WORKSPACE}/$TEMP_DIR/usecase-2" \
               "/Workspace/Deployments/test/files/src/usecase-2" \
               --overwrite
           elif [ "${{ github.event.inputs.use_case }}" = "usecase-1" ]; then
             echo "Uploading usecase-1..."
             databricks workspace import-dir \
-              "$TEMP_DIR/usecase-1" \
+              "${GITHUB_WORKSPACE}/$TEMP_DIR/usecase-1" \
               "/Workspace/Deployments/test/files/src/usecase-1" \
               --overwrite
           elif [ "${{ github.event.inputs.use_case }}" = "usecase-2" ]; then
             echo "Uploading usecase-2..."
             databricks workspace import-dir \
-              "$TEMP_DIR/usecase-2" \
+              "${GITHUB_WORKSPACE}/$TEMP_DIR/usecase-2" \
               "/Workspace/Deployments/test/files/src/usecase-2" \
               --overwrite
           fi
           
-          # Clean up temp directory
+          # Return to workspace directory
+          cd "${GITHUB_WORKSPACE}"
+          
+          # Clean up temp directory (ensure we're in the right directory)
+          cd "${GITHUB_WORKSPACE}"
           rm -rf "$TEMP_DIR"
           
           # Deploy cluster configuration


### PR DESCRIPTION
Root cause: When databricks.yml exists in the repo, ALL databricks commands require a target, even basic workspace operations.

Solution: Execute databricks workspace commands from parent directory to avoid bundle config detection.

Changes:
- Move to parent directory (cd ..) before workspace commands
- Use ${GITHUB_WORKSPACE} for absolute paths
- Return to workspace directory after commands
- Applied to both backup and deployment steps
- Fixed in both TEST and PROD workflows

This should resolve:
1. 'please specify target' errors during deployment
2. Empty backup folders issue
3. Failed workspace operations